### PR TITLE
Refactor protocol implementation to qube-proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "pretty_env_logger",
+ "qube-proto",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
@@ -134,11 +134,20 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "9695f8df41bb4f3d222c95a67532365f569318332d03d5f3f67f37b20e6ebdf0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "qube-proto"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]
@@ -186,12 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62049b2877bf12821e8f9ad256ee38fdc31db7387ec2d3b3f403024de2034aea"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,15 +226,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.146"
+version = "1.0.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217ca874ae0207aac254aa02c957ded05585a90892cc8d87f9e5fa49669dadd8"
+checksum = "3084b546a1dd6289475996f182a22aba973866ea8e8b02c51d9f46b1336a22da"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -466,3 +469,9 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "zmij"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f4a4e8e9dc5c62d159f04fcdbe07f4c3fb710415aab4754bf11505501e3251d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["server"]
+members = ["server", "qube-proto"]
 
 [workspace.package]
 version = "0.1.0"

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,127 @@
+#:schema https://dystroy.org/bacon/.bacon.schema.json
+
+# This is a configuration file for the bacon tool
+#
+# Complete help on configuration: https://dystroy.org/bacon/config/
+#
+# You may check the current default at
+#   https://github.com/Canop/bacon/blob/main/defaults/default-bacon.toml
+
+default_job = "check"
+env.CARGO_TERM_COLOR = "always"
+
+[jobs.check]
+command = ["cargo", "check"]
+need_stdout = false
+
+[jobs.check-all]
+command = ["cargo", "check", "--all-targets"]
+need_stdout = false
+
+# Run clippy on the default target
+[jobs.clippy]
+command = ["cargo", "clippy"]
+need_stdout = false
+
+# Run clippy on all targets
+# To disable some lints, you may change the job this way:
+#    [jobs.clippy-all]
+#    command = [
+#        "cargo", "clippy",
+#        "--all-targets",
+#    	 "--",
+#    	 "-A", "clippy::bool_to_int_with_if",
+#    	 "-A", "clippy::collapsible_if",
+#    	 "-A", "clippy::derive_partial_eq_without_eq",
+#    ]
+# need_stdout = false
+[jobs.clippy-all]
+command = ["cargo", "clippy", "--all-targets"]
+need_stdout = false
+
+# Run clippy in pedantic mode
+# The 'dismiss' feature may come handy
+[jobs.pedantic]
+command = [
+	"cargo", "clippy",
+	"--",
+	"-W", "clippy::pedantic",
+]
+need_stdout = false
+
+# This job lets you run
+# - all tests: bacon test
+# - a specific test: bacon test -- config::test_default_files
+# - the tests of a package: bacon test -- -- -p config
+[jobs.test]
+command = ["cargo", "test"]
+need_stdout = true
+
+[jobs.nextest]
+command = [
+    "cargo", "nextest", "run",
+    "--hide-progress-bar", "--failure-output", "final"
+]
+need_stdout = true
+analyzer = "nextest"
+
+[jobs.doc]
+command = ["cargo", "doc", "--no-deps"]
+need_stdout = false
+
+# If the doc compiles, then it opens in your browser and bacon switches
+# to the previous job
+[jobs.doc-open]
+command = ["cargo", "doc", "--no-deps", "--open"]
+need_stdout = false
+on_success = "back" # so that we don't open the browser at each change
+
+# You can run your application and have the result displayed in bacon,
+# if it makes sense for this crate.
+[jobs.run]
+command = [
+    "cargo", "run",
+    # put launch parameters for your program behind a `--` separator
+]
+need_stdout = true
+allow_warnings = true
+background = true
+
+# Run your long-running application (eg server) and have the result displayed in bacon.
+# For programs that never stop (eg a server), `background` is set to false
+# to have the cargo run output immediately displayed instead of waiting for
+# program's end.
+# 'on_change_strategy' is set to `kill_then_restart` to have your program restart
+# on every change (an alternative would be to use the 'F5' key manually in bacon).
+# If you often use this job, it makes sense to override the 'r' key by adding
+# a binding `r = job:run-long` at the end of this file .
+# A custom kill command such as the one suggested below is frequently needed to kill
+# long running programs (uncomment it if you need it)
+[jobs.run-long]
+command = [
+    "cargo", "run",
+    # put launch parameters for your program behind a `--` separator
+]
+need_stdout = true
+allow_warnings = true
+background = false
+on_change_strategy = "kill_then_restart"
+# kill = ["pkill", "-TERM", "-P"]
+
+# This parameterized job runs the example of your choice, as soon
+# as the code compiles.
+# Call it as
+#    bacon ex -- my-example
+[jobs.ex]
+command = ["cargo", "run", "--example"]
+need_stdout = true
+allow_warnings = true
+
+# You may define here keybindings that would be specific to
+# a project, for example a shortcut to launch a specific job.
+# Shortcuts to internal functions (scrolling, toggling, etc.)
+# should go in your personal global prefs.toml file instead.
+[keybindings]
+# alt-m = "job:my-job"
+c = "job:clippy-all" # comment this to have 'c' run clippy on only the default target
+p = "job:pedantic" 

--- a/qube-proto/Cargo.toml
+++ b/qube-proto/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "qube-proto"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.148"
+uuid = "1.19.0"
+
+[lints]
+workspace = true

--- a/qube-proto/src/identifier.rs
+++ b/qube-proto/src/identifier.rs
@@ -12,6 +12,7 @@ impl Identifier {
     /// # Examples
     ///
     /// ```
+    /// use qube_proto::Identifier;
     /// let brand = Identifier::try_from("minecraft:brand").unwrap();
     /// assert_eq!(brand.namespace(), "minecraft");
     /// ```
@@ -25,6 +26,7 @@ impl Identifier {
     /// # Examples
     ///
     /// ```
+    /// use qube_proto::Identifier;
     /// let brand = Identifier::try_from("minecraft:brand").unwrap();
     /// assert_eq!(brand.value(), "brand");
     /// ```

--- a/qube-proto/src/identifier.rs
+++ b/qube-proto/src/identifier.rs
@@ -1,0 +1,73 @@
+use std::{error::Error, fmt::Display};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Identifier {
+    namespace: String,
+    value: String,
+}
+
+impl Identifier {
+    pub fn minecraft<T: AsRef<str>>(value: T) -> Self {
+        Self {
+            namespace: "minecraft".to_string(),
+            value: value.as_ref().to_string(),
+        }
+    }
+}
+
+impl Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.namespace, self.value)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IdentifierParseError {
+    InvalidNamespace,
+    InvalidValue,
+}
+
+impl Display for IdentifierParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "failed to parse identifier due to {}",
+            match self {
+                Self::InvalidNamespace => "invalid namespace",
+                Self::InvalidValue => "invalid value",
+            }
+        )
+    }
+}
+
+impl Error for IdentifierParseError {}
+
+impl TryFrom<&str> for Identifier {
+    type Error = IdentifierParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        let (namespace, value) = value.split_once(':').unwrap_or(("minecraft", value));
+
+        if !namespace.chars().all(|c| {
+            c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-' || c == '_'
+        }) {
+            return Err(IdentifierParseError::InvalidNamespace);
+        }
+
+        if !value.chars().all(|c| {
+            c.is_ascii_lowercase()
+                || c.is_ascii_digit()
+                || c == '.'
+                || c == '-'
+                || c == '_'
+                || c == '/'
+        }) {
+            return Err(IdentifierParseError::InvalidValue);
+        }
+
+        Ok(Self {
+            namespace: namespace.to_string(),
+            value: value.to_string(),
+        })
+    }
+}

--- a/qube-proto/src/identifier.rs
+++ b/qube-proto/src/identifier.rs
@@ -7,11 +7,32 @@ pub struct Identifier {
 }
 
 impl Identifier {
-    pub fn minecraft<T: AsRef<str>>(value: T) -> Self {
-        Self {
-            namespace: "minecraft".to_string(),
-            value: value.as_ref().to_string(),
-        }
+    /// Get the namespace.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let brand = Identifier::try_from("minecraft:brand").unwrap();
+    /// assert_eq!(brand.namespace(), "minecraft");
+    /// ```
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    /// Get the value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let brand = Identifier::try_from("minecraft:brand").unwrap();
+    /// assert_eq!(brand.value(), "brand");
+    /// ```
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub fn minecraft<T: AsRef<str>>(value: T) -> Result<Self, IdentifierParseError> {
+        Self::try_from(format!("minecraft:{}", value.as_ref()).as_str())
     }
 }
 
@@ -25,6 +46,8 @@ impl Display for Identifier {
 pub enum IdentifierParseError {
     InvalidNamespace,
     InvalidValue,
+    EmptyNamespace,
+    EmptyValue,
 }
 
 impl Display for IdentifierParseError {
@@ -35,6 +58,8 @@ impl Display for IdentifierParseError {
             match self {
                 Self::InvalidNamespace => "invalid namespace",
                 Self::InvalidValue => "invalid value",
+                Self::EmptyNamespace => "empty namespace",
+                Self::EmptyValue => "empty value",
             }
         )
     }
@@ -63,6 +88,14 @@ impl TryFrom<&str> for Identifier {
                 || c == '/'
         }) {
             return Err(IdentifierParseError::InvalidValue);
+        }
+
+        if namespace.is_empty() {
+            return Err(IdentifierParseError::EmptyNamespace);
+        }
+
+        if value.is_empty() {
+            return Err(IdentifierParseError::EmptyValue);
         }
 
         Ok(Self {

--- a/qube-proto/src/identifier.rs
+++ b/qube-proto/src/identifier.rs
@@ -15,6 +15,7 @@ impl Identifier {
     /// let brand = Identifier::try_from("minecraft:brand").unwrap();
     /// assert_eq!(brand.namespace(), "minecraft");
     /// ```
+    #[must_use]
     pub fn namespace(&self) -> &str {
         &self.namespace
     }
@@ -27,6 +28,7 @@ impl Identifier {
     /// let brand = Identifier::try_from("minecraft:brand").unwrap();
     /// assert_eq!(brand.value(), "brand");
     /// ```
+    #[must_use]
     pub fn value(&self) -> &str {
         &self.value
     }

--- a/qube-proto/src/identifier.rs
+++ b/qube-proto/src/identifier.rs
@@ -46,6 +46,12 @@ impl Display for Identifier {
     }
 }
 
+impl PartialEq<(&str, &str)> for Identifier {
+    fn eq(&self, other: &(&str, &str)) -> bool {
+        self.namespace() == other.0 && self.value() == other.1
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum IdentifierParseError {
     InvalidNamespace,

--- a/qube-proto/src/io.rs
+++ b/qube-proto/src/io.rs
@@ -161,9 +161,9 @@ impl<T: Write> WriteExt for T {
         self.write_u8(value.into())
     }
 
-    fn write_varint(&mut self, mut value: i32) -> std::io::Result<()> {
+    fn write_varint(&mut self, value: i32) -> std::io::Result<()> {
+        let mut value = value as u32;
         loop {
-            #[allow(clippy::cast_sign_loss)]
             let mut byte = (value & 0b0111_1111) as u8;
             value >>= 7;
             if value != 0 {
@@ -178,9 +178,9 @@ impl<T: Write> WriteExt for T {
         }
     }
 
-    fn write_varlong(&mut self, mut value: i64) -> std::io::Result<()> {
+    fn write_varlong(&mut self, value: i64) -> std::io::Result<()> {
+        let mut value = value as u64;
         loop {
-            #[allow(clippy::cast_sign_loss)]
             let mut byte = (value & 0b0111_1111) as u8;
             value >>= 7;
             if value != 0 {

--- a/qube-proto/src/io.rs
+++ b/qube-proto/src/io.rs
@@ -1,0 +1,206 @@
+use std::io::{Read, Write};
+
+use crate::invalid_data;
+
+/// An extension trait for `std::io::Read` with methods for reading integers and floating-point
+/// types, as well as some Minecraft specific types like varints and varlongs.
+pub trait ReadExt: Read {
+    fn read_u8(&mut self) -> std::io::Result<u8>;
+    fn read_u16(&mut self) -> std::io::Result<u16>;
+    fn read_u32(&mut self) -> std::io::Result<u32>;
+    fn read_u64(&mut self) -> std::io::Result<u64>;
+    fn read_u128(&mut self) -> std::io::Result<u128>;
+
+    fn read_i8(&mut self) -> std::io::Result<i8>;
+    fn read_i16(&mut self) -> std::io::Result<i16>;
+    fn read_i32(&mut self) -> std::io::Result<i32>;
+    fn read_i64(&mut self) -> std::io::Result<i64>;
+    fn read_i128(&mut self) -> std::io::Result<i128>;
+
+    fn read_f32(&mut self) -> std::io::Result<f32>;
+    fn read_f64(&mut self) -> std::io::Result<f64>;
+
+    fn read_bool(&mut self) -> std::io::Result<bool>;
+
+    fn read_varint(&mut self) -> std::io::Result<i32>;
+    fn read_varlong(&mut self) -> std::io::Result<i64>;
+
+    fn read_string(&mut self) -> std::io::Result<String>;
+}
+
+macro_rules! impl_read_simple {
+    ($name:ident $ty:ty) => {
+        fn $name(&mut self) -> std::io::Result<$ty> {
+            let mut buffer = [0; size_of::<$ty>()];
+            self.read_exact(&mut buffer)?;
+            Ok(<$ty>::from_be_bytes(buffer))
+        }
+    };
+}
+
+impl<T: Read> ReadExt for T {
+    impl_read_simple!(read_u8 u8);
+    impl_read_simple!(read_u16 u16);
+    impl_read_simple!(read_u32 u32);
+    impl_read_simple!(read_u64 u64);
+    impl_read_simple!(read_u128 u128);
+
+    impl_read_simple!(read_i8 i8);
+    impl_read_simple!(read_i16 i16);
+    impl_read_simple!(read_i32 i32);
+    impl_read_simple!(read_i64 i64);
+    impl_read_simple!(read_i128 i128);
+
+    impl_read_simple!(read_f32 f32);
+    impl_read_simple!(read_f64 f64);
+
+    fn read_bool(&mut self) -> std::io::Result<bool> {
+        match self.read_u8()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            other => Err(invalid_data(&format!("Read bad value for bool: {other}"))),
+        }
+    }
+
+    fn read_varint(&mut self) -> std::io::Result<i32> {
+        let mut value = 0_i32;
+
+        for i in 0..5 {
+            let byte: i32 = self.read_u8()?.into();
+            value |= (byte & 0b0111_1111) << (i * 7);
+
+            if (byte & 0b1000_0000) == 0 {
+                return Ok(value);
+            }
+        }
+
+        Err(invalid_data("Invalid varint"))
+    }
+
+    fn read_varlong(&mut self) -> std::io::Result<i64> {
+        let mut value = 0_i64;
+
+        for i in 0..10 {
+            let byte: i64 = self.read_u8()?.into();
+            value |= (byte & 0b0111_1111) << (i * 7);
+
+            if (byte & 0b1000_0000) == 0 {
+                return Ok(value);
+            }
+        }
+
+        Err(invalid_data("Invalid varlong"))
+    }
+
+    fn read_string(&mut self) -> std::io::Result<String> {
+        let Ok(length): Result<usize, _> = self.read_varint()?.try_into() else {
+            return Err(invalid_data("Negative string length"));
+        };
+
+        let mut buffer = vec![0_u8; length];
+        self.read_exact(&mut buffer)?;
+
+        let Ok(string) = String::from_utf8(buffer) else {
+            return Err(invalid_data("Non-UTF8 string"));
+        };
+        Ok(string)
+    }
+}
+
+/// An extension trait for `std::io::Write` with methods for writing integers and floating-point
+/// types, as well as some Minecraft specific types like varints and varlongs.
+pub trait WriteExt: Write {
+    fn write_u8(&mut self, value: u8) -> std::io::Result<()>;
+    fn write_u16(&mut self, value: u16) -> std::io::Result<()>;
+    fn write_u32(&mut self, value: u32) -> std::io::Result<()>;
+    fn write_u64(&mut self, value: u64) -> std::io::Result<()>;
+    fn write_u128(&mut self, value: u128) -> std::io::Result<()>;
+
+    fn write_i8(&mut self, value: i8) -> std::io::Result<()>;
+    fn write_i16(&mut self, value: i16) -> std::io::Result<()>;
+    fn write_i32(&mut self, value: i32) -> std::io::Result<()>;
+    fn write_i64(&mut self, value: i64) -> std::io::Result<()>;
+    fn write_i128(&mut self, value: i128) -> std::io::Result<()>;
+
+    fn write_f32(&mut self, value: f32) -> std::io::Result<()>;
+    fn write_f64(&mut self, value: f64) -> std::io::Result<()>;
+
+    fn write_bool(&mut self, value: bool) -> std::io::Result<()>;
+
+    fn write_varint(&mut self, value: i32) -> std::io::Result<()>;
+    fn write_varlong(&mut self, value: i64) -> std::io::Result<()>;
+
+    fn write_string(&mut self, value: &str) -> std::io::Result<()>;
+}
+
+macro_rules! impl_write_simple {
+    ($name:ident $ty:ty) => {
+        fn $name(&mut self, value: $ty) -> std::io::Result<()> {
+            self.write_all(&value.to_be_bytes())
+        }
+    };
+}
+
+impl<T: Write> WriteExt for T {
+    impl_write_simple!(write_u8 u8);
+    impl_write_simple!(write_u16 u16);
+    impl_write_simple!(write_u32 u32);
+    impl_write_simple!(write_u64 u64);
+    impl_write_simple!(write_u128 u128);
+
+    impl_write_simple!(write_i8 i8);
+    impl_write_simple!(write_i16 i16);
+    impl_write_simple!(write_i32 i32);
+    impl_write_simple!(write_i64 i64);
+    impl_write_simple!(write_i128 i128);
+
+    impl_write_simple!(write_f32 f32);
+    impl_write_simple!(write_f64 f64);
+
+    fn write_bool(&mut self, value: bool) -> std::io::Result<()> {
+        self.write_u8(value.into())
+    }
+
+    fn write_varint(&mut self, mut value: i32) -> std::io::Result<()> {
+        loop {
+            #[allow(clippy::cast_sign_loss)]
+            let mut byte = (value & 0b0111_1111) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0b1000_0000;
+            }
+
+            self.write_u8(byte)?;
+
+            if value == 0 {
+                return Ok(());
+            }
+        }
+    }
+
+    fn write_varlong(&mut self, mut value: i64) -> std::io::Result<()> {
+        loop {
+            #[allow(clippy::cast_sign_loss)]
+            let mut byte = (value & 0b0111_1111) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0b1000_0000;
+            }
+
+            self.write_u8(byte)?;
+
+            if value == 0 {
+                return Ok(());
+            }
+        }
+    }
+
+    fn write_string(&mut self, value: &str) -> std::io::Result<()> {
+        let Ok(length) = i32::try_from(value.len()) else {
+            return Err(invalid_data("String too long"));
+        };
+
+        self.write_varint(length)?;
+        self.write_all(value.as_bytes())
+    }
+}

--- a/qube-proto/src/io.rs
+++ b/qube-proto/src/io.rs
@@ -162,7 +162,7 @@ impl<T: Write> WriteExt for T {
     }
 
     fn write_varint(&mut self, value: i32) -> std::io::Result<()> {
-        let mut value = value as u32;
+        let mut value = value.cast_unsigned();
         loop {
             let mut byte = (value & 0b0111_1111) as u8;
             value >>= 7;
@@ -179,7 +179,7 @@ impl<T: Write> WriteExt for T {
     }
 
     fn write_varlong(&mut self, value: i64) -> std::io::Result<()> {
-        let mut value = value as u64;
+        let mut value = value.cast_unsigned();
         loop {
             let mut byte = (value & 0b0111_1111) as u8;
             value >>= 7;

--- a/qube-proto/src/lib.rs
+++ b/qube-proto/src/lib.rs
@@ -1,0 +1,327 @@
+use std::{
+    fmt::Debug,
+    io::{ErrorKind, Read, Write},
+};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::io::{ReadExt, WriteExt};
+
+pub mod identifier;
+pub mod io;
+
+pub use identifier::*;
+
+/// Create an invalid data error message.
+pub(crate) fn invalid_data(message: &str) -> std::io::Error {
+    std::io::Error::new(ErrorKind::InvalidData, message)
+}
+
+pub trait Packet: Sized + Debug + Clone + Eq {
+    const OPCODE: i32;
+
+    fn read(r: impl Read) -> std::io::Result<Self>;
+    fn write(self, w: impl Write) -> std::io::Result<()>;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Protocol {
+    Handshake,
+    Status,
+    Login,
+    Configuration,
+    Play,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HandshakeIntent {
+    Status = 1,
+    Login = 2,
+    Transfer = 3,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Handshake {
+    pub protocol_version: i32,
+    pub server_address: String,
+    pub server_port: u16,
+    pub intent: HandshakeIntent,
+}
+impl Packet for Handshake {
+    const OPCODE: i32 = 0x0;
+
+    fn read(mut r: impl Read) -> std::io::Result<Self> {
+        Ok(Self {
+            protocol_version: r.read_varint()?,
+            server_address: r.read_string()?,
+            server_port: r.read_u16()?,
+            intent: match r.read_varint()? {
+                1 => Ok(HandshakeIntent::Status),
+                2 => Ok(HandshakeIntent::Login),
+                3 => Ok(HandshakeIntent::Transfer),
+                _ => Err(invalid_data("Invalid handshake intent.")),
+            }?,
+        })
+    }
+
+    fn write(self, mut w: impl Write) -> std::io::Result<()> {
+        w.write_varint(self.protocol_version)?;
+        w.write_string(&self.server_address)?;
+        w.write_u16(self.server_port)?;
+        w.write_varint(match self.intent {
+            HandshakeIntent::Status => 1,
+            HandshakeIntent::Login => 2,
+            HandshakeIntent::Transfer => 3,
+        })?;
+
+        Ok(())
+    }
+}
+
+/// A status request packet from the client, the server should respond with a `StatusResponse`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StatusRequest;
+impl Packet for StatusRequest {
+    const OPCODE: i32 = 0x0;
+
+    fn read(_: impl Read) -> std::io::Result<Self> {
+        Ok(Self)
+    }
+
+    fn write(self, _: impl Write) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A ping request packet from the client, the server should respond with a `PingResponse` using the
+/// same payload value.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PingRequest(pub i64);
+impl Packet for PingRequest {
+    const OPCODE: i32 = 0x1;
+
+    fn read(mut r: impl Read) -> std::io::Result<Self> {
+        Ok(Self(r.read_i64()?))
+    }
+
+    fn write(self, mut w: impl Write) -> std::io::Result<()> {
+        w.write_i64(self.0)
+    }
+}
+
+/// Information about the server version sent to the client during a status check.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct VersionInfo {
+    pub name: String,
+    pub protocol: u32,
+}
+
+/// Information about the server send to the client during a status check.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct ServerStatus {
+    pub version: VersionInfo,
+    #[serde(rename = "enforcesSecureChat")]
+    pub enforces_secure_chat: bool,
+}
+
+/// A response to `StatusRequest` containing information about the server status.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StatusResponse(pub ServerStatus);
+impl Packet for StatusResponse {
+    const OPCODE: i32 = 0x0;
+
+    fn read(mut r: impl Read) -> std::io::Result<Self> {
+        let string = r.read_string()?;
+        let decoded = serde_json::from_str(&string)?;
+        Ok(Self(decoded))
+    }
+
+    fn write(self, mut w: impl Write) -> std::io::Result<()> {
+        let string = serde_json::to_string(&self.0)?;
+        w.write_string(&string)
+    }
+}
+
+/// A response to `PingRequest` containing the same payload.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PongResponse(pub i64);
+impl Packet for PongResponse {
+    const OPCODE: i32 = 0x01;
+
+    fn read(mut r: impl Read) -> std::io::Result<Self> {
+        Ok(Self(r.read_i64()?))
+    }
+
+    fn write(self, mut w: impl Write) -> std::io::Result<()> {
+        w.write_i64(self.0)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LoginStart {
+    pub name: String,
+    pub uuid: Uuid,
+}
+
+impl Packet for LoginStart {
+    const OPCODE: i32 = 0x00;
+
+    fn read(mut r: impl Read) -> std::io::Result<Self> {
+        Ok(Self {
+            name: r.read_string()?,
+            uuid: Uuid::from_u128(r.read_u128()?),
+        })
+    }
+
+    fn write(self, mut w: impl Write) -> std::io::Result<()> {
+        w.write_string(&self.name)?;
+        w.write_u128(self.uuid.as_u128())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LoginAcknowledged;
+impl Packet for LoginAcknowledged {
+    const OPCODE: i32 = 0x3;
+
+    fn read(_: impl Read) -> std::io::Result<Self> {
+        Ok(Self)
+    }
+
+    fn write(self, _: impl Write) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GameProfileProperty {
+    pub name: String,
+    pub value: String,
+    pub signature: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LoginSuccess {
+    pub uuid: Uuid,
+    pub name: String,
+    pub properties: Vec<GameProfileProperty>,
+}
+impl Packet for LoginSuccess {
+    const OPCODE: i32 = 0x2;
+
+    fn read(mut r: impl Read) -> std::io::Result<Self> {
+        fn read_property(mut r: impl Read) -> std::io::Result<GameProfileProperty> {
+            Ok(GameProfileProperty {
+                name: r.read_string()?,
+                value: r.read_string()?,
+                signature: if r.read_bool()? {
+                    Some(r.read_string()?)
+                } else {
+                    None
+                },
+            })
+        }
+
+        Ok(Self {
+            uuid: Uuid::from_u128(r.read_u128()?),
+            name: r.read_string()?,
+            properties: (0..r.read_varint()?)
+                .map(|_| read_property(&mut r))
+                .collect::<std::io::Result<Vec<_>>>()?,
+        })
+    }
+
+    fn write(self, mut w: impl Write) -> std::io::Result<()> {
+        w.write_u128(self.uuid.as_u128())?;
+        w.write_string(&self.name)?;
+
+        let Ok(property_count) = self.properties.len().try_into() else {
+            return Err(invalid_data("Too many game profile properties."));
+        };
+        w.write_varint(property_count)?;
+
+        for property in self.properties {
+            w.write_string(&property.name)?;
+            w.write_string(&property.value)?;
+
+            w.write_bool(property.signature.is_some())?;
+            if let Some(signature) = property.signature {
+                w.write_string(&signature)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PluginMessage {
+    pub channel: Identifier,
+    pub data: Vec<u8>,
+}
+impl Packet for PluginMessage {
+    const OPCODE: i32 = 0x2;
+
+    fn read(mut r: impl Read) -> std::io::Result<Self> {
+        let channel = Identifier::try_from(r.read_string()?.as_str())
+            .map_err(|e| invalid_data(&format!("Invalid identifier due to {e}")))?;
+        let mut data = Vec::new();
+        r.read_to_end(&mut data)?;
+        Ok(Self { channel, data })
+    }
+
+    fn write(self, mut w: impl Write) -> std::io::Result<()> {
+        w.write_string(&self.channel.to_string())?;
+        w.write_all(&self.data)
+    }
+}
+
+macro_rules! impl_packet_group {
+    (pub enum $name:ident { $($variant:ident($ty:ty) in $protocol:path,)* }) => {
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        pub enum $name {
+            $($variant($ty),)*
+        }
+
+        impl $name {
+            /// Read a `$name` using the current protocol.
+            pub fn read(mut r: impl Read, protocol: Protocol) -> std::io::Result<Self> {
+                let opcode = r.read_varint()?;
+                match (protocol, opcode) {
+                    $(($protocol, <$ty>::OPCODE) => <$ty>::read(r).map($name::$variant),)*
+                    (protocol, opcode) => Err(invalid_data(&format!(
+                        "Unknown opcode {opcode} for {protocol:?}"
+                    ))),
+                }
+            }
+
+            /// Write a `$name`.
+            pub fn write(self, w: impl Write) -> std::io::Result<()> {
+                match self {
+                    $($name::$variant(x) => x.write(w),)*
+                }
+            }
+        }
+    };
+}
+
+impl_packet_group! {
+    pub enum ServerboundPacket {
+        Handshake(Handshake) in Protocol::Handshake,
+        StatusRequest(StatusRequest) in Protocol::Status,
+        PingRequest(PingRequest) in Protocol::Status,
+        LoginStart(LoginStart) in Protocol::Login,
+        LoginAcknowledged(LoginAcknowledged) in Protocol::Login,
+        PluginMessage(PluginMessage) in Protocol::Configuration,
+    }
+}
+
+impl_packet_group! {
+    pub enum ClientboundPacket {
+        StatusResponse(StatusResponse) in Protocol::Status,
+        PongResponse(PongResponse) in Protocol::Status,
+        LoginSuccess(LoginSuccess) in Protocol::Login,
+        PluginMessage(PluginMessage) in Protocol::Configuration,
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 [dependencies]
 log = "0.4.29"
 pretty_env_logger = "0.5.0"
+qube-proto = { version = "0.1.0", path = "../qube-proto" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.146"
 tokio = { version = "1.48.0", features = ["io-util", "macros", "net", "rt", "rt-multi-thread"] }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,17 +1,18 @@
 use std::{
-    error::Error,
-    fmt::Display,
-    io::{Cursor, ErrorKind, Read, Write},
+    io::{Cursor, ErrorKind},
     net::SocketAddr,
 };
 
 use log::{debug, info, warn};
-use serde::Serialize;
+use qube_proto::{
+    Handshake, HandshakeIntent, LoginStart, LoginSuccess, Packet, PingRequest, PluginMessage,
+    PongResponse, Protocol, ServerStatus, ServerboundPacket, StatusResponse, VersionInfo,
+    io::{ReadExt, WriteExt},
+};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
 };
-use uuid::Uuid;
 
 pub trait AsyncReadVarInt: AsyncReadExt {
     fn read_varint(&mut self) -> impl Future<Output = std::io::Result<i32>>;
@@ -57,443 +58,22 @@ impl<T: AsyncWriteExt + Unpin> AsyncWriteVarInt for T {
     }
 }
 
-pub trait ReadExt: Read {
-    fn read_u8(&mut self) -> std::io::Result<u8>;
-    fn read_u16(&mut self) -> std::io::Result<u16>;
-    fn read_u128(&mut self) -> std::io::Result<u128>;
-
-    fn read_i64(&mut self) -> std::io::Result<i64>;
-
-    fn read_varint(&mut self) -> std::io::Result<i32>;
-    fn read_varlong(&mut self) -> std::io::Result<i64>;
-
-    fn read_string(&mut self) -> std::io::Result<String>;
-}
-
-impl<T: Read> ReadExt for T {
-    fn read_u8(&mut self) -> std::io::Result<u8> {
-        let mut buffer = [0; 1];
-        self.read_exact(&mut buffer)?;
-        Ok(u8::from_be_bytes(buffer))
-    }
-
-    fn read_u16(&mut self) -> std::io::Result<u16> {
-        let mut buffer = [0; 2];
-        self.read_exact(&mut buffer)?;
-        Ok(u16::from_be_bytes(buffer))
-    }
-
-    fn read_u128(&mut self) -> std::io::Result<u128> {
-        let mut buffer = [0; 16];
-        self.read_exact(&mut buffer)?;
-        Ok(u128::from_be_bytes(buffer))
-    }
-
-    fn read_i64(&mut self) -> std::io::Result<i64> {
-        let mut buffer = [0; 8];
-        self.read_exact(&mut buffer)?;
-        Ok(i64::from_be_bytes(buffer))
-    }
-
-    fn read_varint(&mut self) -> std::io::Result<i32> {
-        let mut value = 0_i32;
-
-        for i in 0..5 {
-            let byte: i32 = self.read_u8()?.into();
-            value |= (byte & 0b0111_1111) << (i * 7);
-
-            if (byte & 0b1000_0000) == 0 {
-                return Ok(value);
-            }
-        }
-
-        Err(invalid_data("Invalid varint"))
-    }
-
-    fn read_varlong(&mut self) -> std::io::Result<i64> {
-        let mut value = 0_i64;
-
-        for i in 0..10 {
-            let byte: i64 = self.read_u8()?.into();
-            value |= (byte & 0b0111_1111) << (i * 7);
-
-            if (byte & 0b1000_0000) == 0 {
-                return Ok(value);
-            }
-        }
-
-        Err(invalid_data("Invalid varlong"))
-    }
-
-    fn read_string(&mut self) -> std::io::Result<String> {
-        let Ok(length): Result<usize, _> = self.read_varint()?.try_into() else {
-            return Err(invalid_data("Negative string length"));
-        };
-
-        let mut buffer = vec![0_u8; length];
-        self.read_exact(&mut buffer)?;
-
-        let Ok(string) = String::from_utf8(buffer) else {
-            return Err(invalid_data("Non-UTF8 string"));
-        };
-        Ok(string)
-    }
-}
-
-pub trait WriteExt: Write {
-    fn write_u8(&mut self, value: u8) -> std::io::Result<()>;
-    fn write_u16(&mut self, value: u16) -> std::io::Result<()>;
-    fn write_u128(&mut self, value: u128) -> std::io::Result<()>;
-
-    fn write_i64(&mut self, value: i64) -> std::io::Result<()>;
-
-    fn write_bool(&mut self, value: bool) -> std::io::Result<()>;
-
-    fn write_varint(&mut self, value: i32) -> std::io::Result<()>;
-    fn write_varlong(&mut self, value: i64) -> std::io::Result<()>;
-
-    fn write_string(&mut self, value: &str) -> std::io::Result<()>;
-}
-
-impl<T: Write> WriteExt for T {
-    fn write_u8(&mut self, value: u8) -> std::io::Result<()> {
-        self.write_all(&[value])
-    }
-
-    fn write_u16(&mut self, value: u16) -> std::io::Result<()> {
-        self.write_all(&value.to_be_bytes())
-    }
-
-    fn write_u128(&mut self, value: u128) -> std::io::Result<()> {
-        self.write_all(&value.to_be_bytes())
-    }
-
-    fn write_i64(&mut self, value: i64) -> std::io::Result<()> {
-        self.write_all(&value.to_be_bytes())
-    }
-
-    fn write_bool(&mut self, value: bool) -> std::io::Result<()> {
-        self.write_u8(value.into())
-    }
-
-    fn write_varint(&mut self, mut value: i32) -> std::io::Result<()> {
-        loop {
-            #[allow(clippy::cast_sign_loss)]
-            let mut byte = (value & 0b0111_1111) as u8;
-            value >>= 7;
-            if value != 0 {
-                byte |= 0b1000_0000;
-            }
-
-            self.write_u8(byte)?;
-
-            if value == 0 {
-                return Ok(());
-            }
-        }
-    }
-
-    fn write_varlong(&mut self, mut value: i64) -> std::io::Result<()> {
-        loop {
-            #[allow(clippy::cast_sign_loss)]
-            let mut byte = (value & 0b0111_1111) as u8;
-            value >>= 7;
-            if value != 0 {
-                byte |= 0b1000_0000;
-            }
-
-            self.write_u8(byte)?;
-
-            if value == 0 {
-                return Ok(());
-            }
-        }
-    }
-
-    fn write_string(&mut self, value: &str) -> std::io::Result<()> {
-        let Ok(length) = i32::try_from(value.len()) else {
-            return Err(invalid_data("String too long"));
-        };
-
-        self.write_varint(length)?;
-        self.write_all(value.as_bytes())
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ProtocolMode {
-    Handshake = 0,
-    Status = 1,
-    Login = 2,
-    Play = 3,
-    Configuration = 4,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum HandshakeIntent {
-    Status = 1,
-    Login = 2,
-    Transfer = 3,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct PingRequest {
-    timestamp: i64,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Identifier {
-    namespace: String,
-    value: String,
-}
-
-impl Identifier {
-    pub fn minecraft<T: AsRef<str>>(value: T) -> Self {
-        Self {
-            namespace: "minecraft".to_string(),
-            value: value.as_ref().to_string(),
-        }
-    }
-}
-
-impl Display for Identifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}:{}", self.namespace, self.value)
-    }
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum IdentifierParseError {
-    InvalidNamespace,
-    InvalidValue,
-}
-
-impl Display for IdentifierParseError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "failed to parse identifier due to {}",
-            match self {
-                Self::InvalidNamespace => "invalid namespace",
-                Self::InvalidValue => "invalid value",
-            }
-        )
-    }
-}
-
-impl Error for IdentifierParseError {}
-
-impl TryFrom<&str> for Identifier {
-    type Error = IdentifierParseError;
-
-    fn try_from(value: &str) -> Result<Self, Self::Error> {
-        let (namespace, value) = value.split_once(':').unwrap_or(("minecraft", value));
-
-        if !namespace.chars().all(|c| {
-            c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-' || c == '_'
-        }) {
-            return Err(IdentifierParseError::InvalidNamespace);
-        }
-
-        if !value.chars().all(|c| {
-            c.is_ascii_lowercase()
-                || c.is_ascii_digit()
-                || c == '.'
-                || c == '-'
-                || c == '_'
-                || c == '/'
-        }) {
-            return Err(IdentifierParseError::InvalidValue);
-        }
-
-        Ok(Self {
-            namespace: namespace.to_string(),
-            value: value.to_string(),
-        })
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ServerboundPacket {
-    Handshake {
-        protocol_version: i32,
-        server_address: String,
-        server_port: u16,
-        intent: HandshakeIntent,
-    },
-    StatusRequest,
-    PingRequest(i64),
-    LoginStart {
-        name: String,
-        uuid: Uuid,
-    },
-    LoginAcknowledged,
-    PluginMessage {
-        channel: Identifier,
-        data: Vec<u8>,
-    },
-}
-
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct VersionInfo {
-    name: String,
-    protocol: u32,
-}
-
-#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
-pub struct ServerStatus {
-    version: VersionInfo,
-    #[serde(rename = "enforcesSecureChat")]
-    enforces_secure_chat: bool,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct GameProfileProperty {
-    name: String,
-    value: String,
-    signature: Option<String>,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ClientboundPacket {
-    StatusResponse(ServerStatus),
-    PongResponse(i64),
-    LoginSuccess {
-        uuid: Uuid,
-        name: String,
-        properties: Vec<GameProfileProperty>,
-    },
-}
-
-/// Decodes a serverbound packet using the Handshake protocol from the provided reader.
-fn decode_handshake(mut packet: impl Read) -> std::io::Result<ServerboundPacket> {
-    let 0x0 = packet.read_varint()? else {
-        return Err(invalid_data("Handshake opcode must be 0x0"));
-    };
-
-    let protocol_version = packet.read_varint()?;
-    let server_address = packet.read_string()?;
-    let server_port = packet.read_u16()?;
-    let intent = match packet.read_varint()? {
-        1 => Ok(HandshakeIntent::Status),
-        2 => Ok(HandshakeIntent::Login),
-        3 => Ok(HandshakeIntent::Transfer),
-        _ => Err(std::io::Error::new(
-            ErrorKind::InvalidData,
-            "Invalid handshake intent.",
-        )),
-    }?;
-
-    Ok(ServerboundPacket::Handshake {
-        protocol_version,
-        server_address,
-        server_port,
-        intent,
-    })
-}
-
-/// Decodes a serverbound packet using the Status protocol from the provided reader.
-fn decode_status(mut packet: impl Read) -> std::io::Result<ServerboundPacket> {
-    let opcode = packet.read_varint()?;
-    match opcode {
-        0x0 => Ok(ServerboundPacket::StatusRequest),
-        0x1 => packet.read_i64().map(ServerboundPacket::PingRequest),
-        other => Err(invalid_data(&format!("Unknown status opcode: {other}"))),
-    }
-}
-
-fn decode_login(mut packet: impl Read) -> std::io::Result<ServerboundPacket> {
-    let opcode = packet.read_varint()?;
-    match opcode {
-        0x0 => {
-            let name = packet.read_string()?;
-            let uuid = Uuid::from_u128(packet.read_u128()?);
-            Ok(ServerboundPacket::LoginStart { name, uuid })
-        }
-        0x3 => Ok(ServerboundPacket::LoginAcknowledged),
-        other => Err(invalid_data(&format!("Unknown login opcode: {other}"))),
-    }
-}
-
-fn decode_configuration(mut packet: impl Read) -> std::io::Result<ServerboundPacket> {
-    let opcode = packet.read_varint()?;
-    match opcode {
-        0x02 => {
-            let channel = Identifier::try_from(packet.read_string()?.as_str())
-                .map_err(|err| invalid_data(&err.to_string()))?;
-            let mut data = Vec::new();
-            packet.read_to_end(&mut data)?;
-            Ok(ServerboundPacket::PluginMessage { channel, data })
-        }
-        other => Err(invalid_data(&format!(
-            "Unknown configuration opcode: {other}"
-        ))),
-    }
-}
-
-/// Dispatches packet decoding according to the current protocol mode.
-fn read_packet(packet: impl Read, protocol: ProtocolMode) -> std::io::Result<ServerboundPacket> {
-    match protocol {
-        ProtocolMode::Handshake => decode_handshake(packet),
-        ProtocolMode::Status => decode_status(packet),
-        ProtocolMode::Login => decode_login(packet),
-        ProtocolMode::Configuration => decode_configuration(packet),
-        ProtocolMode::Play => Err(invalid_data("Play protocol not supported yet")),
-    }
-}
-
-fn write_packet(mut buffer: impl Write, packet: ClientboundPacket) -> std::io::Result<()> {
-    match packet {
-        ClientboundPacket::StatusResponse(payload) => {
-            buffer.write_varint(0x0)?;
-            buffer.write_string(&serde_json::to_string(&payload)?)?;
-        }
-        ClientboundPacket::PongResponse(payload) => {
-            buffer.write_varint(0x1)?;
-            buffer.write_i64(payload)?;
-        }
-        ClientboundPacket::LoginSuccess {
-            uuid,
-            name,
-            properties,
-        } => {
-            buffer.write_varint(0x2)?;
-            buffer.write_u128(uuid.as_u128())?;
-            buffer.write_string(&name)?;
-
-            let Ok(properties_len) = i32::try_from(properties.len()) else {
-                return Err(invalid_data("Too many game profile properties"));
-            };
-
-            buffer.write_varint(properties_len)?;
-            for property in properties {
-                buffer.write_string(&property.name)?;
-                buffer.write_string(&property.value)?;
-                buffer.write_bool(property.signature.is_some())?;
-                if let Some(signature) = property.signature {
-                    buffer.write_string(&signature)?;
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
 #[derive(Debug)]
 struct Client {
     stream: TcpStream,
-    protocol_mode: ProtocolMode,
+    protocol: Protocol,
     brand: Option<String>,
 }
 
 impl Client {
-    /// Sends a `ClientboundPacket` to the connected peer. The packet is serialized into bytes, prefixed with its length as a varint, and written to the client's TCP stream.
-    async fn send(&mut self, packet: ClientboundPacket) -> std::io::Result<()> {
+    /// Sends a `Packet` to the connected peer. The packet is serialized into bytes,
+    /// prefixed with its length as a varint, and written to the client's TCP stream.
+    async fn send<T: Packet>(&mut self, packet: T) -> std::io::Result<()> {
         debug!("Sending: {packet:?}");
 
         let mut buffer = Cursor::new(Vec::new());
-        write_packet(&mut buffer, packet)?;
+        WriteExt::write_varint(&mut buffer, T::OPCODE)?;
+        packet.write(&mut buffer)?;
         let body = buffer.into_inner();
 
         let Ok(length) = i32::try_from(body.len()) else {
@@ -507,15 +87,15 @@ impl Client {
 
 async fn handle(packet: ServerboundPacket, client: &mut Client) -> std::io::Result<()> {
     match packet {
-        ServerboundPacket::Handshake { intent, .. } => {
-            client.protocol_mode = match intent {
-                HandshakeIntent::Status => ProtocolMode::Status,
-                HandshakeIntent::Login | HandshakeIntent::Transfer => ProtocolMode::Login,
+        ServerboundPacket::Handshake(Handshake { intent, .. }) => {
+            client.protocol = match intent {
+                HandshakeIntent::Status => Protocol::Status,
+                HandshakeIntent::Login | HandshakeIntent::Transfer => Protocol::Login,
             }
         }
-        ServerboundPacket::StatusRequest => {
+        ServerboundPacket::StatusRequest(_) => {
             client
-                .send(ClientboundPacket::StatusResponse(ServerStatus {
+                .send(StatusResponse(ServerStatus {
                     version: VersionInfo {
                         name: "1.21.11".to_string(),
                         protocol: 774,
@@ -524,30 +104,28 @@ async fn handle(packet: ServerboundPacket, client: &mut Client) -> std::io::Resu
                 }))
                 .await?;
         }
-        ServerboundPacket::PingRequest(payload) => {
-            client
-                .send(ClientboundPacket::PongResponse(payload))
-                .await?;
+        ServerboundPacket::PingRequest(PingRequest(payload)) => {
+            client.send(PongResponse(payload)).await?;
         }
-        ServerboundPacket::LoginStart { name, uuid } => {
+        ServerboundPacket::LoginStart(LoginStart { name, uuid }) => {
             client
-                .send(ClientboundPacket::LoginSuccess {
+                .send(LoginSuccess {
                     uuid,
                     name,
                     properties: Vec::new(),
                 })
                 .await?;
         }
-        ServerboundPacket::LoginAcknowledged => client.protocol_mode = ProtocolMode::Configuration,
-        ServerboundPacket::PluginMessage { channel, data }
-            if channel == Identifier::minecraft("brand") =>
+        ServerboundPacket::LoginAcknowledged(_) => client.protocol = Protocol::Configuration,
+        ServerboundPacket::PluginMessage(PluginMessage { channel, data })
+            if channel == ("minecraft", "brand") =>
         {
             let mut data = Cursor::new(data);
             let brand = data.read_string()?;
             info!("Client brand: {brand}");
             client.brand = Some(brand);
         }
-        ServerboundPacket::PluginMessage { channel, .. } => {
+        ServerboundPacket::PluginMessage(PluginMessage { channel, .. }) => {
             warn!("Unknown plugin channel: {channel}");
         }
     }
@@ -565,7 +143,7 @@ fn invalid_data(message: &str) -> std::io::Error {
 async fn process_socket(stream: TcpStream, addr: SocketAddr) -> std::io::Result<()> {
     let mut client = Client {
         stream,
-        protocol_mode: ProtocolMode::Handshake,
+        protocol: Protocol::Handshake,
         brand: None,
     };
     info!("Client at {addr} connected");
@@ -579,7 +157,7 @@ async fn process_socket(stream: TcpStream, addr: SocketAddr) -> std::io::Result<
         let mut buffer = vec![0; length];
         client.stream.read_exact(&mut buffer).await?;
 
-        let packet = read_packet(Cursor::new(buffer), client.protocol_mode)?;
+        let packet = ServerboundPacket::read(Cursor::new(buffer), client.protocol)?;
         debug!("Received: {packet:?}");
 
         handle(packet, &mut client).await?;


### PR DESCRIPTION
Refactors protocol implementation out to `qube-proto`

Macro-ifies the numeric read/write extensions and implements for remaining types.
All packets now have a read and a write method to allow for future round trip fuzz testing 
Adds a default bacon.toml file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive bacon configuration: jobs, run modes, background/long-run support, keybindings and usage examples.
  * Introduced a new protocol library: packet-based networking, handshake/status/login flows, plugin messaging, identifier parsing, and binary I/O helpers.

* **Chores**
  * Workspace expanded to include the new protocol crate; server updated to use the protocol library.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->