### PR TITLE
Add hot reloading config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,6 +65,16 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "indexmap"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is-terminal"
@@ -160,6 +182,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "uuid",
 ]
 
@@ -251,6 +274,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +337,45 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.10+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "unicode-ident"
@@ -470,6 +541,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 
 [[package]]
 name = "zmij"

--- a/qube-proto/src/lib.rs
+++ b/qube-proto/src/lib.rs
@@ -117,10 +117,29 @@ pub struct VersionInfo {
     pub protocol: u32,
 }
 
+/// Information about the play count sent to the client during a status check.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct PlayersInfo {
+    pub max: u32,
+    pub online: u32,
+}
+
+/// The text component format, historically also known as raw JSON text, is used
+/// by Minecraft to send and display rich-text to players.
+///
+/// It can also be sent by players themselves using commands (such as /tellraw and /title)
+/// and data packs.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct TextComponent {
+    pub text: String,
+}
+
 /// Information about the server send to the client during a status check.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct ServerStatus {
     pub version: VersionInfo,
+    pub players: Option<PlayersInfo>,
+    pub description: Option<TextComponent>,
     #[serde(rename = "enforcesSecureChat")]
     pub enforces_secure_chat: bool,
 }

--- a/qube-server/Cargo.toml
+++ b/qube-server/Cargo.toml
@@ -15,7 +15,8 @@ pretty_env_logger = "0.5.0"
 qube-proto = { version = "0.1.0", path = "../qube-proto" }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.146"
-tokio = { version = "1.48.0", features = ["io-util", "macros", "net", "rt", "rt-multi-thread"] }
+tokio = { version = "1.48.0", features = ["fs", "io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+toml = "0.9.10"
 uuid = "1.19.0"
 
 [lints]

--- a/qube-server/src/config.rs
+++ b/qube-server/src/config.rs
@@ -1,0 +1,48 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for the server. Deserialised from a qube.config.toml file.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Config {
+    pub networking: NetworkingConfig,
+    pub status: StatusConfig,
+}
+
+/// Networking configuration
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkingConfig {
+    pub address: IpAddr,
+    pub port: u16,
+}
+
+impl NetworkingConfig {
+    /// The socket address from the IP address and port number.
+    pub fn socket_addr(&self) -> SocketAddr {
+        (self.address, self.port).into()
+    }
+}
+
+impl Default for NetworkingConfig {
+    fn default() -> Self {
+        Self {
+            address: Ipv4Addr::UNSPECIFIED.into(),
+            port: 25565,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StatusConfig {
+    pub message: String,
+    pub max_players: u32,
+}
+
+impl Default for StatusConfig {
+    fn default() -> Self {
+        Self {
+            message: "Hello, Qube!".to_string(),
+            max_players: 25,
+        }
+    }
+}

--- a/qube-server/src/main.rs
+++ b/qube-server/src/main.rs
@@ -158,9 +158,9 @@ fn invalid_data(message: &str) -> std::io::Error {
 
 /// Process a client TCP connection, reading framed packets and handling them until the connection ends or an error occurs.
 ///
-/// This function runs the connection loop for a single client: it repeatedly reads a length, reads that many bytes as a packet 
-/// payload, decodes the packet according to the client's current protocol mode, and dispatches it to the handler which may update 
-/// the client's state or send responses. It returns an I/O error when socket operations fail or when a decoded length is 
+/// This function runs the connection loop for a single client: it repeatedly reads a length, reads that many bytes as a packet
+/// payload, decodes the packet according to the client's current protocol mode, and dispatches it to the handler which may update
+/// the client's state or send responses. It returns an I/O error when socket operations fail or when a decoded length is
 /// invalid (e.g., negative).
 async fn process_socket(
     stream: TcpStream,
@@ -240,7 +240,10 @@ async fn watch<T: for<'a> Deserialize<'a> + Serialize + Sync + Send + Eq + Defau
 
             if *tx.borrow() != updated {
                 let Ok(()) = tx.send(updated) else {
-                    error!("Failed to send updated value from change to {}", path.display());
+                    error!(
+                        "Failed to send updated value from change to {}",
+                        path.display()
+                    );
                     return;
                 };
                 info!("Applied changes from {}", path.display());

--- a/qube-server/src/main.rs
+++ b/qube-server/src/main.rs
@@ -203,11 +203,14 @@ async fn watch<T: for<'a> Deserialize<'a> + Serialize + Sync + Send + Eq + Defau
                 "Can't find {}, creating file using default value...",
                 path.display()
             );
+
             let default = T::default();
-            std::fs::write(
-                "qube.config.toml",
+            tokio::fs::write(
+                &path,
                 toml::to_string(&default).map_err(|e| invalid_data(&e.to_string()))?,
-            )?;
+            )
+            .await?;
+
             default
         }
         other => other?,
@@ -229,7 +232,7 @@ async fn watch<T: for<'a> Deserialize<'a> + Serialize + Sync + Send + Eq + Defau
                     error!("Failed to send updated server config");
                     return;
                 };
-                info!("Applied changes from qube.config.toml");
+                info!("Applied changes from {}", path.display());
             }
         }
     });

--- a/qube-server/src/main.rs
+++ b/qube-server/src/main.rs
@@ -223,7 +223,7 @@ async fn watch<T: for<'a> Deserialize<'a> + Serialize + Sync + Send + Eq + Defau
             tokio::time::sleep(Duration::from_secs(1)).await;
 
             let Ok(new_config) = read(&path).await else {
-                error!("Failed to read updated qube.config.toml");
+                error!("Failed to read updated file: {}", path.display());
                 continue;
             };
 

--- a/qube-server/src/main.rs
+++ b/qube-server/src/main.rs
@@ -158,9 +158,9 @@ fn invalid_data(message: &str) -> std::io::Error {
 
 /// Process a client TCP connection, reading framed packets and handling them until the connection ends or an error occurs.
 ///
-/// This function runs the connection loop for a single client: it repeatedly reads a length, reads that many bytes as a packet
-/// payload, decodes the packet according to the client's current protocol mode, and dispatches it to the handler which may update
-/// the client's state or send responses. It returns an I/O error when socket operations fail or when a decoded length is
+/// This function runs the connection loop for a single client: it repeatedly reads a length, reads that many bytes as a packet 
+/// payload, decodes the packet according to the client's current protocol mode, and dispatches it to the handler which may update 
+/// the client's state or send responses. It returns an I/O error when socket operations fail or when a decoded length is 
 /// invalid (e.g., negative).
 async fn process_socket(
     stream: TcpStream,
@@ -234,13 +234,13 @@ async fn watch<T: for<'a> Deserialize<'a> + Serialize + Sync + Send + Eq + Defau
             tokio::time::sleep(Duration::from_secs(1)).await;
 
             let Ok(updated) = read(&path).await else {
-                error!("Failed to read updated file: {}", path.display());
+                error!("Failed to read update to {}", path.display());
                 continue;
             };
 
             if *tx.borrow() != updated {
                 let Ok(()) = tx.send(updated) else {
-                    error!("Failed to send updated value");
+                    error!("Failed to send updated value from change to {}", path.display());
                     return;
                 };
                 info!("Applied changes from {}", path.display());

--- a/qube.config.toml
+++ b/qube.config.toml
@@ -1,0 +1,7 @@
+[networking]
+address = "0.0.0.0"
+port = 25565
+
+[status]
+message = "Hello, Qube!!!"
+max_players = 400

--- a/qube.config.toml
+++ b/qube.config.toml
@@ -3,5 +3,5 @@ address = "0.0.0.0"
 port = 25565
 
 [status]
-message = "Hello, Qube!!!"
-max_players = 400
+message = "Hello, Qube!"
+max_players = 25


### PR DESCRIPTION
Adds a `qube.config.toml` file which current contains 
options for networking and status info.

This config file is hot reloaded where possible, but not all changes should be hot reloaded i.e. server address and port shouldn't be applied without a restart because it would break all connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server supports a TOML config to customize bind address/port, status message, and max players; a default config is created if missing.
  * Configuration is watched and applied live so changes take effect without restarting the server.
  * Status responses now include player counts and a customizable description.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->